### PR TITLE
Unikanie inkrementacji iteratora koncowego.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@
 *.app
 
 .idea
-cmake*
+out
+_Resharper.Caches
+.vs
 
 cmake_modules

--- a/Bullet.cpp
+++ b/Bullet.cpp
@@ -1,5 +1,7 @@
 #include "Bullet.h"
 
+#include <numbers>
+
 void Bullet::draw(sf::RenderTarget& target, sf::RenderStates state) const
 {
     target.draw(this->shape, state);
@@ -9,7 +11,7 @@ Bullet::Bullet(sf::Vector2f ownerPosition, float ownerRotation, float bulletSpee
 {
     shape.setTexture(texture);
     float rotation = ownerRotation - 4 + rand() % 9;
-    velocity = {sinf(rotation * M_PI / 180.0) * bulletSpeed, -cosf(rotation * M_PI / 180.0) * bulletSpeed};
+    velocity = {sinf(rotation * std::numbers::pi / 180.0) * bulletSpeed, -cosf(rotation * std::numbers::pi / 180.0) * bulletSpeed};
     //velocity += owner.getVelocity();
     shape.setPosition(ownerPosition);
     shape.setScale(0.6,0.6);

--- a/Unit.cpp
+++ b/Unit.cpp
@@ -1,5 +1,7 @@
 #include "Unit.h"
 
+#include <numbers>
+
 void Unit::draw(sf::RenderTarget& target, sf::RenderStates state) const
 {
     target.draw(this->shape, state);
@@ -29,8 +31,8 @@ void Unit::update()
     {
         float rotation = getRotation();
 
-        sf::Vector2f acceleration = {sinf(rotation * M_PI / 180.0) * accelerationStraight / 10 + cosf(rotation * M_PI / 180.0) * accelerationSideways / 10,
-        -cosf(rotation * M_PI / 180.0) * accelerationStraight / 10 + sinf(rotation * M_PI / 180.0) * accelerationSideways / 10};
+        sf::Vector2f acceleration = {sinf(rotation * std::numbers::pi / 180.0) * accelerationStraight / 10 + cosf(rotation * std::numbers::pi / 180.0) * accelerationSideways / 10,
+        -cosf(rotation * std::numbers::pi / 180.0) * accelerationStraight / 10 + sinf(rotation * std::numbers::pi / 180.0) * accelerationSideways / 10};
 
         velocity += acceleration;
     }
@@ -75,13 +77,13 @@ void Unit::rotate(float degree)
 void Unit::moveForwardBackward(float distance)
 {
     float rotation = getRotation();
-    shape.move(sf::Vector2f{cosf(rotation * M_PI / 180.0) * distance, sinf(rotation * M_PI / 180.0) * distance});
+    shape.move(sf::Vector2f{cosf(rotation * std::numbers::pi / 180.0) * distance, sinf(rotation * std::numbers::pi / 180.0) * distance});
 }
 
 void Unit::moveLeftRight(float distance)
 {
     float rotation = getRotation();
-    shape.move(sf::Vector2f{sinf(-rotation * M_PI / 180.0) * distance, cosf(-rotation * M_PI / 180.0) * distance});
+    shape.move(sf::Vector2f{sinf(-rotation * std::numbers::pi / 180.0) * distance, cosf(-rotation * std::numbers::pi / 180.0) * distance});
 }
 
 void Unit::move(sf::Vector2f offset)

--- a/main.cpp
+++ b/main.cpp
@@ -1,14 +1,18 @@
-#include <SFML/Graphics.hpp>
-#include <SFML/Audio.hpp>
-#include "Unit.h"
-#include "Bullet.h"
-#include "Background.h"
-#include <iostream>
-#include <algorithm>
 #include "Animation.h"
+#include "Background.h"
+#include "Bullet.h"
 #include "MainMenu.h"
 #include "Particle.h"
+#include "Unit.h"
 
+#include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <numbers>
+#include <filesystem>
 
 #pragma region enumsAndStructures
 
@@ -66,6 +70,7 @@ void bulletsUpdate(std::vector<bulletElement> &vbel, sf::RenderWindow &w)
 int main()
 {
 
+    std::cout << std::filesystem::current_path().string() << '\n';
 #pragma region declarations
 
     bool gameRunning = false;
@@ -418,8 +423,8 @@ int main()
             float angle = player.unit.getRotation() - view.getRotation();
             sf::Vector2f deltaPosition = player.unit.getPosition() - view.getCenter();
 
-            view.move(deltaPosition.x - playerCameraOffset * sin(-angle * M_PI / 180.0),
-                      deltaPosition.y - playerCameraOffset * cos(-angle * M_PI / 180.0));
+            view.move(deltaPosition.x - playerCameraOffset * sin(-angle * std::numbers::pi / 180.0),
+                      deltaPosition.y - playerCameraOffset * cos(-angle * std::numbers::pi / 180.0));
 
             float oldrotation = view.getRotation();
             view.setRotation(player.unit.getRotation());
@@ -436,9 +441,14 @@ int main()
                     ita->update();
                     if (ita->getCounter() > 0) {
                         window.draw(*ita);
-                    } else if ((animations.size() > 1) && (ita->getCounter() < 0)) {
+                    } else if (ita->getCounter() < 0) {
                         ita = animations.erase(ita);
                     }
+                    if (ita == animations.end())
+                    {
+	                    break;
+                    }
+
                 }
             }
 
@@ -559,7 +569,7 @@ int main()
 
                 for (auto it = enemies.begin(); it != enemies.end(); ++it) {
                     float wantedRotation = atan2f(player.unit.getPosition().y - it->unit.getPosition().y,
-                                                  player.unit.getPosition().x - it->unit.getPosition().x) * 180 / M_PI +
+                                                  player.unit.getPosition().x - it->unit.getPosition().x) * 180 / std::numbers::pi +
                                            90;
                     float enemyRotation = it->unit.getRotation();
                     if (enemyRotation > 180) {
@@ -706,7 +716,7 @@ int main()
                 player.unit.update();
 
                 if (isPlayerAccelerating && drawingPlayer){
-                    float playerRotation = (player.unit.getRotation() + 90) * M_PI / 180.0;
+                    float playerRotation = (player.unit.getRotation() + 90) * std::numbers::pi / 180.0;
                     player.particles.emplace_back(Particle(player.unit.getPosition() +
                                         sf::Vector2f(cosf(playerRotation) * 30,sinf(playerRotation) * 30),
                                         16, sf::Color(220, 220, 250)));


### PR DESCRIPTION
W przypadku korzystania z funkcji std::vector::erase, istnieje możliwość, że jak usuwamy ostatni element, to zwrócony iterator będzie iteratorem `end`. Pętla aktualizacji animacji sie natomiast jeszcze nie skończyła, i zostanie podjęta jeszcze jedna iteracja wskutek czego, iterator końcowy będzie inkrementowany jeszcze raz. Co powoduje odpowiedni crash.